### PR TITLE
Remove album from analysis metapkg.

### DIFF
--- a/pyall/analysis-2015_03/meta.yaml
+++ b/pyall/analysis-2015_03/meta.yaml
@@ -19,4 +19,3 @@ requirements:
     - openpyxl
     - scikit-xray >=v0.5.0
     - xray-vision >=v0.3.0
-    - album >=v0.0.1


### PR DESCRIPTION
I don't think we need this installed by default. It is *probably* a dead project. Too soon to nuke the album recipe entirely though.