### PR TITLE
MNT: Re-introduce configure flag to ncurses

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,9 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
     conda install conda-build anaconda-client && \
     conda remove conda-build
 
+# needed for gobject-introspection
+RUN apt-get install -i flex
+
 
 ENV PATH /opt/conda/bin:$PATH
 

--- a/nonpy/ncurses-5.9/build.sh
+++ b/nonpy/ncurses-5.9/build.sh
@@ -3,7 +3,7 @@
 ./configure --prefix=$PREFIX \
     --without-debug --without-ada --without-manpages \
     --with-shared --disable-overwrite --with-termlib=tinfo \
-    --with-normal 
+    --with-normal --enable-widec
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make install

--- a/nonpy/ncurses-5.9/meta.yaml
+++ b/nonpy/ncurses-5.9/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 8cb9c412e5f2d96bc6f459aa8c6282a1
 
 build:
-  number: 7 
+  number: 8
   detect_binary_files_with_prefix: true
 
 about:


### PR DESCRIPTION
I'm bumping the build number so that this *should* automatically replace any builds with build_number = 7, which apparently are segfaulting!

cc @tacaswell 