### PR TITLE
Add metadatastore v0.4.1

### DIFF
--- a/pyall/metadatastore-0.4.1/build.sh
+++ b/pyall/metadatastore-0.4.1/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i 's|__CONDA_BUILD_PLACEHOLDER__|'$PREFIX'/etc|' metadatastore/conf.py
+
+$PYTHON setup.py install --single-version-externally-managed --record=/dev/null

--- a/pyall/metadatastore-0.4.1/config.patch
+++ b/pyall/metadatastore-0.4.1/config.patch
@@ -1,0 +1,14 @@
+diff --git a/metadatastore/conf.py b/metadatastore/conf.py
+index 5637dc7..10badef 100644
+--- metadatastore/conf.py
++++ metadatastore/conf.py
+@@ -41,7 +41,9 @@ def load_configuration(name, prefix, fields):
+     conf : dict
+         Dictionary keyed on ``fields`` with the values extracted
+     """
++    conda_path = '__CONDA_BUILD_PLACEHOLDER__'
+     filenames = [
++        os.path.join(conda_path, name + '.yml'),
+         os.path.join('/etc', name + '.yml'),
+         os.path.join(os.path.expanduser('~'), '.config', name,
+                      'connection.yml'),

--- a/pyall/metadatastore-0.4.1/meta.yaml
+++ b/pyall/metadatastore-0.4.1/meta.yaml
@@ -1,0 +1,51 @@
+package:
+  name: metadatastore
+  version: 0.4.1
+
+source:
+  git_url: https://github.com/NSLS-II/metadatastore
+  git_rev: v0.4.1
+  patches:
+    - config.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - six
+
+  run:
+    - python
+    - mongoengine
+    - six
+    - pyyaml
+    - prettytable
+    - humanize
+    - numpy
+    - pytz
+    - jinja2
+    - boltons
+    - doct
+
+test:
+  requires:
+    - nslsii_dev_configuration
+
+  imports:
+    # Import all the packages
+    - metadatastore
+    - metadatastore.api
+    - metadatastore.commands
+    - metadatastore.conf
+    - metadatastore.odm_templates
+    - metadatastore.examples
+    - metadatastore.examples.sample_data
+    - metadatastore.examples.sample_data.common
+    - metadatastore.examples.sample_data.multisource_event
+    - metadatastore.examples.sample_data.temperature_ramp
+
+about:
+  home: https://github.com/NSLS-II/metadatastore
+  license: BSD


### PR DESCRIPTION
Note: we never made one for v0.4.0, tagged six days ago, but there's no practical reason to go back for it. v0.4.1 has important fixes.