### PR TITLE
ENH: Use env vars for dev configuration

### DIFF
--- a/nonpy/config-dev/build.sh
+++ b/nonpy/config-dev/build.sh
@@ -1,28 +1,48 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/etc
-ETC=$PREFIX/etc
-
+ACTIVATE=$PREFIX/etc/conda/activate.d/db-env-vars.sh
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/db-env-vars.sh
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
 
 # set up
 echo "# metadatastore configuration
 # installed by nslsii_dev_configuration
 # DO NOT EDIT
-host: localhost
-database: datastore-dev
-port: 27017
-timezone: US/Eastern
-" > $ETC/metadatastore.yml
+export MDS_HOST=localhost
+export MDS_DATABASE=datastore-dev
+export MDS_PORT=27017
+export MDS_TIMEZONE=US/Eastern
+" > $ACTIVATE
 
 echo "# filestore configuration
 # installed by nslsii_dev_configuration
 # DO NOT EDIT
-host: localhost
-database: filestore-dev
-port: 27017
-" > $ETC/filestore.yml
+export FS_HOST=localhost
+export FS_DATABASE=filestore-dev
+export FS_PORT=27017
+" >> $ACTIVATE
+
+echo "#metadataclient configuration
+# installed by nslsii_dev_configuration
+# DO NOT EDIT
+export MDC_HOST=localhost
+export MDC_PORT=7770
+export MDC_PROTOCOL=http
+export MDC_TIMEZONE=\"US/Eastern\"
+" >> $ACTIVATE
+
+echo "unset MDS_HOST
+unset MDS_DATABASE
+unset MDS_PORT
+unset MDS_TIMEZONE
+unset FS_HOST
+unset FS_DATABASE
+unset FS_PORT
+unset MDC_HOST
+unset MDC_PORT
+unset MDC_PROTOCOL
+unset MDC_DATABASE
+" > $DEACTIVATE
 
 
-
-# clean up after self
-unset ETC

--- a/nonpy/config-dev/meta.yaml
+++ b/nonpy/config-dev/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: nslsii_dev_configuration
-  version: '1'
+  version: 3
 
 build:
-  number: 3
+  number: 0
 
 about:
   summary: 'Development environment configurations to point metadatastore and filestore at localhost'

--- a/nonpy/config-dev/pre-unlink.sh
+++ b/nonpy/config-dev/pre-unlink.sh
@@ -1,0 +1,3 @@
+# Clean up after thyself
+rm $PREFIX/etc/conda/activate.d/db-env-vars.sh  
+rm $PREFIX/etc/conda/deactivate.d/db-env-vars.sh  


### PR DESCRIPTION
attn @tacaswell Any reason why this is a bad idea?  I keep getting issues
where the config cannot seem to load values out of the specified 
configuration file location and it greatly annoys me. This fixes that by 
just using env vars. 

Also note the addition of the pre-unlink.sh script that will remove those
two files if/when this package is removed. We should be more careful about
keeping track of the files that we add with our conda packages and clean 
up after ourselves when those packages are removed.